### PR TITLE
Auth as feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -43,10 +43,10 @@ name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.120 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.123 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -55,6 +55,7 @@ dependencies = [
 name = "compute-starter-kit-static-content"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "fastly 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -76,9 +77,9 @@ dependencies = [
  "fastly-sys 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.120 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.123 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.61 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -92,7 +93,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -169,15 +170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -213,6 +214,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,7 +247,7 @@ dependencies = [
  "aho-corasick 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -256,20 +262,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.120"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.120 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.123 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.120"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -279,7 +285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.120 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.123 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -290,12 +296,12 @@ dependencies = [
  "form_urlencoded 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.120 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.123 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -318,15 +324,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -334,14 +340,14 @@ name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.10.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "tinyvec_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -365,7 +371,7 @@ name = "unicode-normalization"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "tinyvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinyvec 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -420,7 +426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 "checksum bytes 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 "checksum chrono 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 "checksum fastly 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b32333410ceb0499e2c98af856a47464231e44e78cbfc4a5c66592c1dd8bd07a"
 "checksum fastly-macros 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9805cc40e0ce43131c09107bf833af402ab102ed2e0bdd1a7f4d9b8789138229"
@@ -434,29 +440,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum itoa 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.82 (registry+https://github.com/rust-lang/crates.io-index)" = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
-"checksum log 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
+"checksum libc 0.2.85 (registry+https://github.com/rust-lang/crates.io-index)" = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+"checksum log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum num-integer 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 "checksum num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+"checksum once_cell 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum proc-macro2 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 "checksum quote 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 "checksum regex 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 "checksum regex-syntax 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)" = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 "checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-"checksum serde 1.0.120 (registry+https://github.com/rust-lang/crates.io-index)" = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
-"checksum serde_derive 1.0.120 (registry+https://github.com/rust-lang/crates.io-index)" = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
+"checksum serde 1.0.123 (registry+https://github.com/rust-lang/crates.io-index)" = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+"checksum serde_derive 1.0.123 (registry+https://github.com/rust-lang/crates.io-index)" = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 "checksum serde_json 1.0.61 (registry+https://github.com/rust-lang/crates.io-index)" = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 "checksum serde_urlencoded 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
-"checksum syn 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)" = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+"checksum syn 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)" = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 "checksum thiserror 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 "checksum thiserror-impl 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
-"checksum thread_local 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
+"checksum thread_local 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
 "checksum time 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-"checksum tinyvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+"checksum tinyvec 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
 "checksum tinyvec_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,13 @@ debug = true
 [dependencies]
 fastly = "0.6.0"
 regex = "1.4.2"
+cfg-if = "1.0.0"
 # required for awsv4 sig gen
 chrono = { version = "0.4.19", optional = true }
 hmac-sha256 = { version = "0.1.6", optional = true }
 hex = { version = "0.4.2", optional = true }
 urlencoding = { version = "1.1.1", optional = true }
 
-
 [features]
-default = []
-
+default = ["auth"]
 auth = ["chrono", "hmac-sha256", "hex", "urlencoding"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,15 @@ debug = true
 
 [dependencies]
 fastly = "0.6.0"
-urlencoding = "1.1.1"
 regex = "1.4.2"
 # required for awsv4 sig gen
 chrono = { version = "0.4.19", optional = true }
 hmac-sha256 = { version = "0.1.6", optional = true }
 hex = { version = "0.4.2", optional = true }
+urlencoding = { version = "1.1.1", optional = true }
 
 
 [features]
 default = []
 
-auth = ["chrono", "hmac-sha256", "hex"]
+auth = ["chrono", "hmac-sha256", "hex", "urlencoding"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,15 @@ debug = true
 
 [dependencies]
 fastly = "0.6.0"
-chrono = "0.4.19"
-hmac-sha256 = "0.1.6"
-hex = "0.4.2"
 urlencoding = "1.1.1"
 regex = "1.4.2"
+# required for awsv4 sig gen
+chrono = { version = "0.4.19", optional = true }
+hmac-sha256 = { version = "0.1.6", optional = true }
+hex = { version = "0.4.2", optional = true }
+
+
+[features]
+default = []
+
+auth = ["chrono", "hmac-sha256", "hex"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If your bucket requires authentication, you will need to create an [edge diction
  * `access_key_id` - The HMAC access key ID for your service account with read access.
  * `secret_access_key` - The HMAC secret key for your service account with read access.
 
- In addition to this, you will need to update the `Cargo.toml` to replace `features = []` with `features = ["auth"]`. This will include the dependencies required to generate signed requests in your package.
+ In addition to this, you will need to update the `Cargo.toml` to replace `default = []` with `default = ["auth"]`. This will include the dependencies required to generate signed requests in your package.
 
 ## Understanding the code
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ If your bucket requires authentication, you will need to create an [edge diction
  * `access_key_id` - The HMAC access key ID for your service account with read access.
  * `secret_access_key` - The HMAC secret key for your service account with read access.
 
+ In addition to this, you will need to update the `Cargo.toml` to replace `features = []` with `features = ["auth"]`. This will include the dependencies required to generate signed requests in your package.
+
 ## Understanding the code
 
-This starter is feature-packed, and requires some extra dependencies dependencies on top of the [`fastly`](https://docs.rs/fastly) crate to handle signing requests for S3/GCS. If you are using a public bucket for your origin, you can remove these dependencies, the `awsv4.rs` file, and modify the `set_authentication_headers` method to reduce the size of your binary.
+This starter is feature-packed, and requires some extra dependencies on top of the [`fastly`](https://docs.rs/fastly) crate to handle signing requests for S3/GCS. If you are using a public bucket for your origin, these dependencies will not be included.
 
 This starter includes implementations of common patterns explained in our [using Compute@Edge](/learning/compute/using/) and [VCL migration](/learning/compute/migrate) guides. Any of the code you see here can be modified or built upon to suit your project's needs.
 

--- a/fastly.toml
+++ b/fastly.toml
@@ -1,4 +1,4 @@
-version = 13
+version = 179
 name = "Compute@Edge static content starter kit for Rust"
 description = "Speed up your websites with a Compute@Edge environment that demonstrates serving content from a static bucket, redirects, security and performance headers, and a 404 page."
 authors = ["<oss@fastly.com>"]

--- a/fastly.toml
+++ b/fastly.toml
@@ -1,4 +1,4 @@
-version = 179
+version = 1
 name = "Compute@Edge static content starter kit for Rust"
 description = "Speed up your websites with a Compute@Edge environment that demonstrates serving content from a static bucket, redirects, security and performance headers, and a 404 page."
 authors = ["<oss@fastly.com>"]

--- a/src/awsv4.rs
+++ b/src/awsv4.rs
@@ -1,5 +1,5 @@
 use chrono::DateTime;
-use chrono::Utc;
+pub use chrono::Utc;
 use hmac_sha256::{Hash, HMAC};
 
 use crate::config::{BUCKET_HOST, BUCKET_NAME, BUCKET_REGION, BUCKET_SERVICE};

--- a/src/awsv4.rs
+++ b/src/awsv4.rs
@@ -1,7 +1,7 @@
 use chrono::DateTime;
-pub use chrono::Utc;
 use hmac_sha256::{Hash, HMAC};
 
+use crate::Utc;
 use crate::config::{BUCKET_HOST, BUCKET_NAME, BUCKET_REGION, BUCKET_SERVICE};
 
 /// SHA256 HMAC

--- a/src/awsv4.rs
+++ b/src/awsv4.rs
@@ -1,4 +1,4 @@
-use chrono::{Utc, DateTime};
+use chrono::{DateTime, Utc};
 use hmac_sha256::{Hash, HMAC};
 
 use crate::config::{BUCKET_HOST, BUCKET_NAME, BUCKET_REGION, BUCKET_SERVICE};

--- a/src/awsv4.rs
+++ b/src/awsv4.rs
@@ -1,7 +1,6 @@
-use chrono::DateTime;
+use chrono::{Utc, DateTime};
 use hmac_sha256::{Hash, HMAC};
 
-use crate::Utc;
 use crate::config::{BUCKET_HOST, BUCKET_NAME, BUCKET_REGION, BUCKET_SERVICE};
 
 /// SHA256 HMAC

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,13 @@ mod config;
 use fastly::http::{header, HeaderValue, Method, StatusCode};
 use fastly::{Error, Request, Response};
 
-#[cfg(feature="auth")]
+#[cfg(feature = "auth")]
 mod awsv4;
 
-#[cfg(feature="auth")]
+#[cfg(feature = "auth")]
 use crate::awsv4::{hash, Utc};
 
-#[cfg(feature="auth")]
+#[cfg(feature = "auth")]
 use fastly::handle::dictionary::DictionaryHandle;
 
 /// The entry point for your application.
@@ -219,8 +219,7 @@ fn set_authentication_headers(req: &mut Request) {
 
 #[cfg(not(feature = "auth"))]
 // Stub for when authentication feature is disabled
-fn set_authentication_headers(_: &mut Request) {
-}
+fn set_authentication_headers(_: &mut Request) {}
 
 /// Removes all headers but those defined in `ALLOWED_HEADERS` from a response.
 fn filter_headers(resp: &mut Response) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,14 +5,14 @@ mod config;
 use fastly::http::{header, HeaderValue, Method, StatusCode};
 use fastly::{Error, Request, Response};
 
-#[cfg(feature = "auth")]
-mod awsv4;
-
-#[cfg(feature = "auth")]
-use crate::awsv4::{hash, Utc};
-
-#[cfg(feature = "auth")]
-use fastly::handle::dictionary::DictionaryHandle;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "auth")] {
+        mod awsv4;
+        use chrono::Utc;
+        use crate::awsv4::hash;
+        use fastly::handle::dictionary::DictionaryHandle;
+    }
+}
 
 /// The entry point for your application.
 ///


### PR DESCRIPTION
This makes all of the auth-related functionality and dependencies reliant on the `auth` Cargo feature being enabled. The README has been updated with instructions on how to do this.

This means customers with public buckets and devs just experimenting will have shorter build times and smaller binaries.