### PR TITLE
Change response code and message for non-allowed methods.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,12 @@ fn main(mut req: Request) -> Result<Response, Error> {
 
     // Only permit GET requests.
     if req.get_method() != Method::GET {
-        return Ok(Response::from_body("Access denied").with_status(StatusCode::FORBIDDEN));
+        return Ok(Response::from_body("Method not allowed")
+            .with_status(StatusCode::METHOD_NOT_ALLOWED)
+            .with_header(
+                header::ALLOW,
+                format!("{}, {}", Method::GET, Method::OPTIONS),
+            ));
     }
 
     // Respond to requests for robots.txt.


### PR DESCRIPTION
Changes the synthetic response for requests with non-allowed methods to a more semantically correct [`405 Method not allowed`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405) with an `Allow` header.

[rfc7231](https://tools.ietf.org/html/rfc7231#section-6.5.5)
>   The 405 (Method Not Allowed) status code indicates that the method
   received in the request-line is known by the origin server but not
   supported by the target resource.  The origin server MUST generate an
   Allow header field in a 405 response containing a list of the target
   resource's currently supported methods.