### PR TITLE
Allow `developer.fastly.com` iframe

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -26,4 +26,4 @@ pub(crate) const BUCKET_REGION: &str = "auto";
 
 /// Define a Content Security Policy for content that can load on your site.
 pub(crate) const CONTENT_SECURITY_POLICY: &str =
-    "default-src 'self'; style-src 'self' fonts.googleapis.com; font-src fonts.gstatic.com";
+    "default-src 'self'; style-src 'self' fonts.googleapis.com; font-src fonts.gstatic.com; frame-src developer.fastly.com";


### PR DESCRIPTION
Currently the iframe content will not load due to CSP configuration.