### PR TITLE
Rename package to enable Fastly CLI v4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "compute-starter-kit-static-content"
+name = "compute-starter-kit-rust"
 version = "0.1.0"
 authors = []
 edition = "2018"


### PR DESCRIPTION
The next release of the Fastly CLI will require all Rust starter kits to use the same package name.