### PR TITLE
Adding service version logging

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -1,8 +1,15 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["<oss@fastly.com>"]
+description = "Apply performance, security and usability upgrades to static bucket services such as Google Cloud Storage or AWS S3."
+language = "rust"
 manifest_version = 2
 name = "Static content"
-description = "Apply performance, security and usability upgrades to static bucket services such as Google Cloud Storage or AWS S3."
-authors = ["<oss@fastly.com>"]
-language = "rust"
+service_id = ""
+
+[scripts]
+  build = "cargo build --bin fastly-compute-project --release --target wasm32-wasi --color always"
 
 [setup]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,9 @@ cfg_if::cfg_if! {
 /// If `main` returns an error, a 500 error response will be delivered to the client.
 #[fastly::main]
 fn main(mut req: Request) -> Result<Response, Error> {
+    // Log service version
+    println!("FASTLY_SERVICE_VERSION: {}", std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new()));
+    
     // Used later to generate CORS headers.
     // Usually you would want an allowlist of domains here, but this example allows any origin to make requests.
     let allowed_origins = match req.get_header(header::ORIGIN) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,11 @@ cfg_if::cfg_if! {
 #[fastly::main]
 fn main(mut req: Request) -> Result<Response, Error> {
     // Log service version
-    println!("FASTLY_SERVICE_VERSION: {}", std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new()));
-    
+    println!(
+        "FASTLY_SERVICE_VERSION: {}",
+        std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new())
+    );
+
     // Used later to generate CORS headers.
     // Usually you would want an allowlist of domains here, but this example allows any origin to make requests.
     let allowed_origins = match req.get_header(header::ORIGIN) {


### PR DESCRIPTION
Prints service version to console after running `fastly log-tail`. ([JIRA ticket](https://fastly.atlassian.net/browse/DEVLIB-856?atlOrigin=eyJpIjoiMDY0MmI0YThjZDVhNGE5NjljZjBiZGNjNTkzOWY2NDMiLCJwIjoiaiJ9))