### PR TITLE
2025 Rust starter kit upgrades

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
-[target.wasm32-wasi]
-rustflags = ["-C", "debuginfo=2"]
-
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
+
+[term]
+color = "always"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,53 +1,14 @@
-on: pull_request
 name: Test
+
+on:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'rust-toolchain.toml'
+      - '.cargo/config.toml'
+      - '.github/workflows/test.yml'
+      - 'src/**'
+
 jobs:
   test:
-    strategy:
-      matrix:
-        rust-toolchain: [1.83.0]
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    environment: test
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.83.0
-    - name: Add wasm32-wasi Rust target
-      run: rustup target add wasm32-wasi --toolchain ${{ matrix.rust-toolchain }}
-    - name: Cache cargo registry
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo index
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo build
-      uses: actions/cache@v3
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install fmt
-      run: rustup component add rustfmt
-      shell: bash
-    - name: Install clippy
-      run: rustup component add clippy
-      shell: bash
-    - name: Install audit
-      run: cargo install cargo-audit
-      shell: bash
-    - name: Check binaries and format
-      run: RUSTFLAGS="--deny warnings" cargo check --bins --target wasm32-wasi && cargo fmt -- --check
-      shell: bash
-    - name: clippy
-      run: cargo clippy
-      shell: bash
-    - name: audit
-      run: cargo audit
-      shell: bash
-    - name: build
-      run: cargo build
-      shell: bash
+    uses: fastly/devex-reusable-workflows/.github/workflows/compute-starter-kit-rust-v1.yml@main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,15 @@
 name = "fastly-compute-project"
 version = "0.1.0"
 authors = []
-edition = "2018"
+edition = "2021"
+# Remove this line if you want to be able to publish this crate on crates.io.
+# Otherwise, `publish = false` prevents an accidental `cargo publish` from revealing private source.
+publish = false
 
 [profile.release]
-debug = true
+debug = 1
+codegen-units = 1
+lto = "fat"
 
 [dependencies]
 cfg-if = "1.0.0"

--- a/fastly.toml
+++ b/fastly.toml
@@ -1,15 +1,14 @@
 # This file describes a Fastly Compute package. To learn more visit:
-# https://developer.fastly.com/reference/fastly-toml/
+# https://www.fastly.com/documentation/reference/compute/fastly-toml/
 
-authors = ["<oss@fastly.com>"]
+name = "Static content"
 description = "Apply performance, security and usability upgrades to static bucket services such as Google Cloud Storage or AWS S3."
+authors = ["<devrel@fastly.com>"]
 language = "rust"
 manifest_version = 3
-name = "Static content"
-service_id = ""
 
 [scripts]
-build = "cargo build --bin fastly-compute-project --release --target wasm32-wasi --color always"
+  build = "cargo build --profile release"
 
 [setup]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "1.83.0"
-targets = [ "wasm32-wasi" ]
+channel = "stable"
+targets = [ "wasm32-wasip1" ]
+profile = "default"

--- a/src/awsv4.rs
+++ b/src/awsv4.rs
@@ -38,10 +38,8 @@ impl SignatureClient {
 
         // These must be sorted alphabetically
         let canonical_headers = format!(
-            "host:{}\nx-amz-content-sha256:{}\nx-amz-date:{}\n",
-            format!("{}.{}", BUCKET_NAME, BUCKET_HOST),
-            amz_content_256,
-            x_amz_date
+            "host:{}.{}\nx-amz-content-sha256:{}\nx-amz-date:{}\n",
+            BUCKET_NAME, BUCKET_HOST, amz_content_256, x_amz_date
         );
 
         let canonical_query = "";
@@ -80,8 +78,8 @@ impl SignatureClient {
         ]
         .iter()
         .fold(
-            sign(&format!("AWS4{}", self.secret_access_token), &x_amz_today),
-            |acc, x| sign(&acc, x),
+            sign(format!("AWS4{}", self.secret_access_token), &x_amz_today),
+            sign,
         );
 
         // Compose authorization header value

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,8 +21,8 @@ pub(crate) const BUCKET_SERVICE: &str = "storage";
 pub(crate) const BUCKET_REGION: &str = "auto";
 
 // If auth is required, configure your access keys in an edge dictionary named "bucket_auth":
-/// access_key_id
-/// secret_access_key
+// - access_key_id
+// - secret_access_key
 
 /// Define a Content Security Policy for content that can load on your site.
 pub(crate) const CONTENT_SECURITY_POLICY: &str =

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn main(mut req: Request) -> Result<Response, Error> {
         // This means the canonical URL for index pages will always end with a trailing slash.
         if !is_not_found(&beresp) {
             beresp = Response::from_status(StatusCode::MOVED_PERMANENTLY)
-                .with_header(header::LOCATION, &format!("{}/", original_path));
+                .with_header(header::LOCATION, format!("{}/", original_path));
             return Ok(beresp);
         }
     }
@@ -186,7 +186,7 @@ fn get_cache_ttl(path: &str) -> u32 {
     }
 
     // Any other content can be cached for 5 minutes.
-    return 60 * 5;
+    60 * 5
 }
 
 /// Determines if a backend response indicates the requested file doesn't exist.


### PR DESCRIPTION
Starter kit content changes:

* Changed 'wasm32-wasi' target to 'wasm32-wasip1' (requires Rust 1.78 or later and Fastly CLI 11.0 or later)

* Changed rust-toolchain.toml to install 'stable' toolchain instead of '1.83.0'

* Moved term.color=always from scripts.build in fastly.toml to .cargo/config.toml

* Updated Rust edition from 2018 to 2021

* Changed Rust 'release' profile to use LTO

* Removed unnecessary parameters from scripts.build in fastly.toml

* 'cargo clippy' fixes

Other changes:

* Switched to using a reusable workflow for CI